### PR TITLE
[VIVO-1865] - Add etag generation config

### DIFF
--- a/vivocore/conf/solrconfig.xml
+++ b/vivocore/conf/solrconfig.xml
@@ -758,7 +758,7 @@
              any query time fq params the user may specify, as a mechanism for
              partitioning the index, independent of any user selected filtering
              that may also be desired (perhaps as a result of faceted searching).
-    
+
              NOTE: there is *absolutely* nothing a client can do to prevent these
              "appends" values from being used, so don't use this mechanism
              unless you are sure you always want it.
@@ -772,14 +772,14 @@
              the options available to Solr clients.  Any params values
              specified here are used regardless of what values may be specified
              in either the query, the "defaults", or the "appends" params.
-    
+
              In this example, the facet.field and facet.query params would
              be fixed, limiting the facets clients can use.  Faceting is
              not turned on by default - but if the client does specify
              facet=true in the request, these are the only facets they
              will be able to see counts for; regardless of what other
              facet.field or facet.query params they may specify.
-    
+
              NOTE: there is *absolutely* nothing a client can do to prevent these
              "invariants" values from being used, so don't use this mechanism
              unless you are sure you always want it.
@@ -804,7 +804,7 @@
           -->
         </requestHandler>
 
- 
+
   <!-- A Robust Example
 
        This example SearchHandler declaration shows off usage of the
@@ -902,6 +902,37 @@
        <str>spellcheck</str>
      </arr>
   </requestHandler>
+
+  <!-- Update Request Handler.
+
+      http://wiki.apache.org/solr/UpdateXmlMessages
+      The canonical Request Handler for Modifying the Index through
+      commands specified using XML, JSON, CSV, or JAVABIN
+      Note: Since solr1.1 requestHandlers requires a valid content
+      type header if posted in the body. For example, curl now
+      requires: -H 'Content-type:text/xml; charset=utf-8'
+
+      To override the request content type and force a specific
+      Content-type, use the request parameter:
+        ?update.contentType=text/csv
+
+      This handler will pick a response format to match the input
+      if the 'wt' parameter is not explicit
+   -->
+ <requestHandler name="/update" class="solr.UpdateRequestHandler">
+   <!-- See below for information on defining
+        updateRequestProcessorChains that can be used by name
+        on each Update Request
+     -->
+     <lst name="defaults">
+        <str name="update.chain">etag</str>
+      </lst>
+   <!--
+      <lst name="defaults">
+        <str name="update.chain">dedupe</str>
+      </lst>
+      -->
+ </requestHandler>
 
 
   <initParams path="/update/**,/query,/select,/tvrh,/elevate,/spell,/browse,update">
@@ -1476,6 +1507,22 @@
       <processor class="solr.RunUpdateProcessorFactory" />
     </updateRequestProcessorChain>
   -->
+
+  <!-- ETag generation
+     Creates the "etag" field on the fly based on a hash of all other
+     fields.
+
+  -->
+   <updateRequestProcessorChain name="etag">
+     <processor class="solr.processor.SignatureUpdateProcessorFactory">
+       <bool name="enabled">true</bool>
+       <str name="signatureField">etag</str>
+       <bool name="overwriteDupes">false</bool>
+       <str name="signatureClass">solr.processor.Lookup3Signature</str>
+     </processor>
+     <processor class="solr.LogUpdateProcessorFactory" />
+     <processor class="solr.RunUpdateProcessorFactory" />
+   </updateRequestProcessorChain>
 
   <!-- Response Writers
 

--- a/vivocore/conf/solrconfig.xml
+++ b/vivocore/conf/solrconfig.xml
@@ -758,7 +758,7 @@
              any query time fq params the user may specify, as a mechanism for
              partitioning the index, independent of any user selected filtering
              that may also be desired (perhaps as a result of faceted searching).
-
+    
              NOTE: there is *absolutely* nothing a client can do to prevent these
              "appends" values from being used, so don't use this mechanism
              unless you are sure you always want it.
@@ -772,14 +772,14 @@
              the options available to Solr clients.  Any params values
              specified here are used regardless of what values may be specified
              in either the query, the "defaults", or the "appends" params.
-
+    
              In this example, the facet.field and facet.query params would
              be fixed, limiting the facets clients can use.  Faceting is
              not turned on by default - but if the client does specify
              facet=true in the request, these are the only facets they
              will be able to see counts for; regardless of what other
              facet.field or facet.query params they may specify.
-
+    
              NOTE: there is *absolutely* nothing a client can do to prevent these
              "invariants" values from being used, so don't use this mechanism
              unless you are sure you always want it.
@@ -804,7 +804,7 @@
           -->
         </requestHandler>
 
-
+ 
   <!-- A Robust Example
 
        This example SearchHandler declaration shows off usage of the
@@ -904,18 +904,15 @@
   </requestHandler>
 
   <!-- Update Request Handler.
-
       http://wiki.apache.org/solr/UpdateXmlMessages
       The canonical Request Handler for Modifying the Index through
       commands specified using XML, JSON, CSV, or JAVABIN
       Note: Since solr1.1 requestHandlers requires a valid content
       type header if posted in the body. For example, curl now
       requires: -H 'Content-type:text/xml; charset=utf-8'
-
       To override the request content type and force a specific
       Content-type, use the request parameter:
         ?update.contentType=text/csv
-
       This handler will pick a response format to match the input
       if the 'wt' parameter is not explicit
    -->
@@ -933,7 +930,6 @@
       </lst>
       -->
  </requestHandler>
-
 
   <initParams path="/update/**,/query,/select,/tvrh,/elevate,/spell,/browse,update">
     <lst name="defaults">
@@ -1511,7 +1507,6 @@
   <!-- ETag generation
      Creates the "etag" field on the fly based on a hash of all other
      fields.
-
   -->
    <updateRequestProcessorChain name="etag">
      <processor class="solr.processor.SignatureUpdateProcessorFactory">


### PR DESCRIPTION
See https://jira.lyrasis.org/browse/VIVO-1865

The solrconfig.xml included does not include processing logic for etags. See etag processing chain from old file here: https://github.com/vivo-project/Vitro/blob/vitro-1.10.0/home/src/main/resources/solr/conf/solrconfig.xml#L1832

Without this fix, the caching scheme described at https://wiki.lyrasis.org/display/VIVODOC111x/Use+HTTP+caching+to+improve+performance does not work.

This pull request copies over the processing chain from the old config. After inclusion, etags are generated again when the search index updates. 