### PR TITLE
Disable log4j message lookup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -22,4 +22,4 @@ else
   echo "vivocore collection already exists";
 fi
 
-exec solr -f
+exec solr-fg


### PR DESCRIPTION
The docker solr images were updated to include the argument -Dlog4j2.formatMsgNoLookups=true to mitigate the log4j vulnerability, see their github page [1](https://github.com/docker-solr/docker-solr/commit/d9aceb632fcad5d5e7ab42b94dd25a008f5b9112) and [2](https://github.com/docker-solr/docker-solr/commit/74d04b4a699f32c2f2a032e0e0c9b44ffe0de810)

The argument is only set when you start your solr container with "solr-fg" or "solr-foreground" or "start-local-solr"